### PR TITLE
Fix install

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,6 +1,5 @@
-includes: ['layer:basic', 'layer:apt', 'interface:http']
-repo: git@github.com/IBCNServices/layer-jupyter-notebook.git
+includes: ['layer:basic', 'interface:http']
+repo: git@github.com/tengu-team/layer-jupyter-notebook.git
 options:
-  apt:
-    packages:
-       - 'python3-pip'
+ basic:
+   use_venv: false

--- a/reactive/jupyter_notebook.py
+++ b/reactive/jupyter_notebook.py
@@ -14,6 +14,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=c0111,c0103,c0301
+import os
 import lsb_release
 import subprocess
 
@@ -31,12 +32,12 @@ def upgrade_charm():
     pip_install('jupyter', upgrade=True)
 
 
-@when('apt.installed.python3-pip')
 @when_not('jupyter-notebook.installed')
 def install_jupyter_notebook():
     hookenv.log("Install Jupyter-notebook")
-    pip_install('pip', upgrade=True)
+    os.environ["LC_ALL"] = "en_US.UTF-8" # Needed for the xkcdpass module
     pip_install('jupyter')
+    pip_install('xkcdpass')    
     set_state('jupyter-notebook.installed')
 
 

--- a/templates/jupyter_notebook_config.py.jinja2
+++ b/templates/jupyter_notebook_config.py.jinja2
@@ -1,6 +1,6 @@
 # Set options for certfile, ip, password, and toggle off
 # Set ip to '*' to bind on all interfaces (ips) for the public server
-c.NotebookApp.ip = '*'
+c.NotebookApp.ip = '0.0.0.0'
 c.NotebookApp.open_browser = False
 
 # It is a good idea to set a known, fixed port for server access

--- a/wheelhouse.txt
+++ b/wheelhouse.txt
@@ -1,1 +1,0 @@
-xkcdpass


### PR DESCRIPTION
Fix for #2.
- Disables the new default behaviour of the basic layer which uses a virtual env. 
- Installs the xkcdpass module via `pip_install`.
- `pip` is no longer updated to the latest version because of an [issue](https://github.com/pypa/pip/issues/5240) in pip version 10. The cause is in the charmhelpers module [here](https://github.com/juju/charm-helpers/blob/master/charmhelpers/contrib/python/packages.py#L47).